### PR TITLE
docs: update badges layout in blog posts from table to paragraph tags

### DIFF
--- a/blog/en/stop-using-katex-use-native-mathml.md
+++ b/blog/en/stop-using-katex-use-native-mathml.md
@@ -1,6 +1,10 @@
 # Stop Using KaTeX/MathJax: Render Math in 3.5KB with Native MathML
 
-<table><tr><td><a href="https://www.npmjs.com/package/@webc.site/math" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.npm.svg" alt="npm" height="60" /></a></td><td><a href="https://github.com/webc-site/math" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.github.svg" alt="github" height="60" /></a></td><td><a href="https://math.webc.site" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.demo.svg" alt="demo" height="60" /></a></td></tr></table>
+<p>
+<a href="https://www.npmjs.com/package/@webc.site/math" target="_blank" style="margin-right: 16px;"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.npm.svg" alt="npm" height="60"></a>
+<a href="https://github.com/webc-site/math" target="_blank" style="margin-right: 16px;"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.github.svg" alt="github" height="60"></a>
+<a href="https://math.webc.site" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/en/svg/badge.demo.svg" alt="demo" height="60"></a>
+</p>
 
 For technical blogs, documentation sites, or any web application supporting Markdown, math formula rendering has always been a heavy burden.
 

--- a/blog/zh/stop-using-katex-use-native-mathml.md
+++ b/blog/zh/stop-using-katex-use-native-mathml.md
@@ -1,6 +1,10 @@
 # 3.5KB 搞定公式渲染！是时候放弃 KaTeX / MathJax，拥抱原生 MathML 了
 
-<table border="0" cellpadding="0" cellspacing="0" frame="void" rules="none"><tr><td height="60" valign="middle"><a href="https://www.npmjs.com/package/@webc.site/math" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.npm.svg" alt="npm" height="60" /></a></td><td height="60" valign="middle">&nbsp;&nbsp;</td><td height="60" valign="middle"><a href="https://github.com/webc-site/math" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.github.svg" alt="github" height="60" /></a></td><td height="60" valign="middle">&nbsp;&nbsp;</td><td height="60" valign="middle"><a href="https://math.webc.site" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.demo.svg" alt="demo" height="60" /></a></td></tr></table>
+<p>
+<a href="https://www.npmjs.com/package/@webc.site/math" target="_blank" style="margin-right: 16px;"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.npm.svg" alt="npm" height="60"></a>
+<a href="https://github.com/webc-site/math" target="_blank" style="margin-right: 16px;"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.github.svg" alt="github" height="60"></a>
+<a href="https://math.webc.site" target="_blank"><img src="https://raw.githubusercontent.com/webc-site/math/dev/readme/zh/svg/badge.demo.svg" alt="demo" height="60"></a>
+</p>
 
 在开发技术博客、文档系统或支持 Markdown 的网页应用时，数学公式渲染一直是一块难以卸下的“巨石”。
 


### PR DESCRIPTION
文档: 更新博客文章中徽章的布局，将表格替换为段落标签